### PR TITLE
feat(schedule): indent host and notes

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -503,9 +503,9 @@ async def make_practice_session_embed(
             )
             value = f"[Add to Google Calendar]({gcal_url})"
             if session.host:
-                value += f"\nHost: {session.host}"
+                value += f"\n> Host: {session.host}"
             if session.notes:
-                value += f"\nNotes: {session.notes}"
+                value += f"\n> Notes: {session.notes}"
             embed.add_field(name=title, value=value, inline=False)
     embed.add_field(
         name="🗓 View or edit the schedule using the link below.",

--- a/tests/__snapshots__/test_bot.ambr
+++ b/tests/__snapshots__/test_bot.ambr
@@ -272,7 +272,7 @@
       colour=<Colour value=15105570>,
       description='Sunday, September 27',
       fields=<class 'list'> [
-        EmbedProxy(inline=False, name='11 AM PDT / 12 PM MDT / 1 PM CDT / 2 PM EDT', value='[Add to Google Calendar](http://www.google.com/calendar/event?action=TEMPLATE&text=ASL+Practice%3A+another+1%EF%B8%8F%E2%83%A3&dates=20200927T180000Z%2F20200927T190000Z&details=See+the+full+schedule+here%3A+https%3A%2F%2Fdocs.google.com%2Fspreadsheets%2Fd%2Fabc%2Fedit)\nNotes: another 1️⃣'),
+        EmbedProxy(inline=False, name='11 AM PDT / 12 PM MDT / 1 PM CDT / 2 PM EDT', value='[Add to Google Calendar](http://www.google.com/calendar/event?action=TEMPLATE&text=ASL+Practice%3A+another+1%EF%B8%8F%E2%83%A3&dates=20200927T180000Z%2F20200927T190000Z&details=See+the+full+schedule+here%3A+https%3A%2F%2Fdocs.google.com%2Fspreadsheets%2Fd%2Fabc%2Fedit)\n> Notes: another 1️⃣'),
         EmbedProxy(inline=True, name='🗓 View or edit the schedule using the link below.', value='[Full schedule](https://docs.google.com/spreadsheets/d/abc/edit)'),
       ],
       footer=EmbedProxy(),
@@ -296,7 +296,7 @@
       colour=<Colour value=15105570>,
       description='Today - Friday, September 25',
       fields=<class 'list'> [
-        EmbedProxy(inline=False, name='2 PM PDT / 3 PM MDT / 4 PM CDT / 5 PM EDT', value='[Add to Google Calendar](http://www.google.com/calendar/event?action=TEMPLATE&text=ASL+Practice%3A+recurring&dates=20200925T210000Z%2F20200925T220000Z&details=See+the+full+schedule+here%3A+https%3A%2F%2Fdocs.google.com%2Fspreadsheets%2Fd%2Fabc%2Fedit)\nHost: Steve\nNotes: recurring'),
+        EmbedProxy(inline=False, name='2 PM PDT / 3 PM MDT / 4 PM CDT / 5 PM EDT', value='[Add to Google Calendar](http://www.google.com/calendar/event?action=TEMPLATE&text=ASL+Practice%3A+recurring&dates=20200925T210000Z%2F20200925T220000Z&details=See+the+full+schedule+here%3A+https%3A%2F%2Fdocs.google.com%2Fspreadsheets%2Fd%2Fabc%2Fedit)\n> Host: Steve\n> Notes: recurring'),
         EmbedProxy(inline=True, name='🗓 View or edit the schedule using the link below.', value='[Full schedule](https://docs.google.com/spreadsheets/d/abc/edit)'),
       ],
       footer=EmbedProxy(),
@@ -320,7 +320,7 @@
       colour=<Colour value=15105570>,
       description='Tomorrow - Saturday, September 26',
       fields=<class 'list'> [
-        EmbedProxy(inline=False, name='2 PM PDT / 3 PM MDT / 4 PM CDT / 5 PM EDT', value='[Add to Google Calendar](http://www.google.com/calendar/event?action=TEMPLATE&text=ASL+Practice%3A+one+time&dates=20200926T210000Z%2F20200926T220000Z&details=See+the+full+schedule+here%3A+https%3A%2F%2Fdocs.google.com%2Fspreadsheets%2Fd%2Fabc%2Fedit)\nHost: Steve\nNotes: one time'),
+        EmbedProxy(inline=False, name='2 PM PDT / 3 PM MDT / 4 PM CDT / 5 PM EDT', value='[Add to Google Calendar](http://www.google.com/calendar/event?action=TEMPLATE&text=ASL+Practice%3A+one+time&dates=20200926T210000Z%2F20200926T220000Z&details=See+the+full+schedule+here%3A+https%3A%2F%2Fdocs.google.com%2Fspreadsheets%2Fd%2Fabc%2Fedit)\n> Host: Steve\n> Notes: one time'),
         EmbedProxy(inline=True, name='🗓 View or edit the schedule using the link below.', value='[Full schedule](https://docs.google.com/spreadsheets/d/abc/edit)'),
       ],
       footer=EmbedProxy(),
@@ -344,7 +344,7 @@
       colour=<Colour value=15105570>,
       description='Today - Friday, September 25',
       fields=<class 'list'> [
-        EmbedProxy(inline=False, name='2 PM PDT / 3 PM MDT / 4 PM CDT / 5 PM EDT', value='[Add to Google Calendar](http://www.google.com/calendar/event?action=TEMPLATE&text=ASL+Practice%3A+recurring&dates=20200925T210000Z%2F20200925T220000Z&details=See+the+full+schedule+here%3A+https%3A%2F%2Fdocs.google.com%2Fspreadsheets%2Fd%2Fabc%2Fedit)\nHost: Steve\nNotes: recurring'),
+        EmbedProxy(inline=False, name='2 PM PDT / 3 PM MDT / 4 PM CDT / 5 PM EDT', value='[Add to Google Calendar](http://www.google.com/calendar/event?action=TEMPLATE&text=ASL+Practice%3A+recurring&dates=20200925T210000Z%2F20200925T220000Z&details=See+the+full+schedule+here%3A+https%3A%2F%2Fdocs.google.com%2Fspreadsheets%2Fd%2Fabc%2Fedit)\n> Host: Steve\n> Notes: recurring'),
         EmbedProxy(inline=True, name='🗓 View or edit the schedule using the link below.', value='[Full schedule](https://docs.google.com/spreadsheets/d/abc/edit)'),
       ],
       footer=EmbedProxy(),
@@ -368,7 +368,7 @@
       colour=<Colour value=15105570>,
       description='Tomorrow - Saturday, September 26',
       fields=<class 'list'> [
-        EmbedProxy(inline=False, name='2 PM PDT / 3 PM MDT / 4 PM CDT / 5 PM EDT', value='[Add to Google Calendar](http://www.google.com/calendar/event?action=TEMPLATE&text=ASL+Practice%3A+one+time&dates=20200926T210000Z%2F20200926T220000Z&details=See+the+full+schedule+here%3A+https%3A%2F%2Fdocs.google.com%2Fspreadsheets%2Fd%2Fabc%2Fedit)\nHost: Steve\nNotes: one time'),
+        EmbedProxy(inline=False, name='2 PM PDT / 3 PM MDT / 4 PM CDT / 5 PM EDT', value='[Add to Google Calendar](http://www.google.com/calendar/event?action=TEMPLATE&text=ASL+Practice%3A+one+time&dates=20200926T210000Z%2F20200926T220000Z&details=See+the+full+schedule+here%3A+https%3A%2F%2Fdocs.google.com%2Fspreadsheets%2Fd%2Fabc%2Fedit)\n> Host: Steve\n> Notes: one time'),
         EmbedProxy(inline=True, name='🗓 View or edit the schedule using the link below.', value='[Full schedule](https://docs.google.com/spreadsheets/d/abc/edit)'),
       ],
       footer=EmbedProxy(),


### PR DESCRIPTION
Discord strips trailing and leading whitespace from embeds, so `\t` or `  ` don't work. Workaround is to use `> `.