### PR TITLE
chore: address DeprecationWarning re: hash-based seeding

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -789,7 +789,7 @@ async def daily_practice_message():
 
 def get_today_random(dtime: Optional[dt.datetime] = None) -> random.Random:
     dtime = dtime or utcnow()
-    seed = DAILY_MESSAGE_RANDOM_SEED or dtime.date().timetuple()
+    seed = DAILY_MESSAGE_RANDOM_SEED or dtime.date().toordinal()
     return random.Random(seed)
 
 


### PR DESCRIPTION
```
/Users/sloria/.pyenv/versions/3.9.0/lib/python3.9/random.py:122: DeprecationWarning: Seeding based on hashing is deprecated
  since Python 3.9 and will be removed in a subsequent version. The only
  supported seed types are: None, int, float, str, bytes, and bytearray.
    self.seed(x)
```
