### PR TITLE
fix(codenames): fix team maker

### DIFF
--- a/bot/exts/games.py
+++ b/bot/exts/games.py
@@ -1,8 +1,7 @@
-import asyncio
 import logging
 import random
 from contextlib import suppress
-from typing import Optional, List, Union, Sequence
+from typing import Iterable, Optional, Union, Sequence
 
 import discord
 from discord.ext.commands import Context, Bot, Cog, command
@@ -87,38 +86,87 @@ class Games(Cog):
             await message.add_reaction("👍")
             await message.add_reaction("🔀")
 
-        def check(reaction, user):
-            return reaction.message.id == message.id
+    @Cog.listener()
+    async def on_raw_reaction_remove(
+        self, payload: discord.RawReactionActionEvent
+    ) -> None:
+        if not self.should_handle_reaction(payload, {"👍"}):
+            return
+        message = await self.get_reaction_message(payload)
+        if not message:
+            return
 
-        players: List[Union[discord.User, discord.Member]] = []
-        while True:
-            done, pending = await asyncio.wait(
-                (
-                    asyncio.create_task(self.bot.wait_for("reaction_add", check=check)),
-                    asyncio.create_task(
-                        self.bot.wait_for("reaction_remove", check=check)
-                    ),
-                ),
-                return_when=asyncio.FIRST_COMPLETED,
+        if str(payload.emoji) == "👍":
+            reaction = next((r for r in message.reactions if str(r.emoji) == "👍"), None)
+            if not reaction:
+                return
+            players = [
+                player
+                for player in await reaction.users().flatten()
+                if player.id != self.bot.user.id
+            ]
+            red, blue = make_teams(players)
+            team_embed = discord.Embed(
+                title="Teams",
+                description=f"🔴 Red: {format_team(red)}\n🔵 Blue: {format_team(blue)}",
             )
-            reaction, _ = done.pop().result()
-            for future in pending:
-                future.cancel()
-            if str(reaction.emoji) in ("👍", "🔀"):
-                if str(reaction.emoji) == "🔀":
-                    logger.info("shuffling players")
-                    random.shuffle(players)
-                else:
-                    players = [
-                        player
-                        for player in await reaction.users().flatten()
-                        if player.id != self.bot.user.id
-                    ]
-                red, blue = make_teams(players)
-                logger.info(f"total players: {len(players)}")
-                await message.edit(
-                    content=f"{base_message}\n🔴 Red: {format_team(red)}\n🔵 Blue: {format_team(blue)}"
-                )
+            await message.edit(embed=team_embed)
+
+    @Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent) -> None:
+        if not self.should_handle_reaction(payload, {"👍", "🔀"}):
+            return
+
+        message = await self.get_reaction_message(payload)
+        if not message:
+            return
+
+        reaction = next((r for r in message.reactions if str(r.emoji) == "👍"), None)
+        if not reaction:
+            return
+        players = [
+            player
+            for player in await reaction.users().flatten()
+            if player.id != self.bot.user.id
+        ]
+        if str(reaction.emoji) == "🔀":
+            random.shuffle(players)
+
+        red, blue = make_teams(players)
+        team_embed = discord.Embed(
+            title="Teams",
+            description=f"🔴 Red: {format_team(red)}\n🔵 Blue: {format_team(blue)}",
+        )
+        await message.edit(embed=team_embed)
+
+    def should_handle_reaction(
+        self, payload: discord.RawReactionActionEvent, emojis: Iterable[str]
+    ) -> bool:
+        # Is this a control emoji?
+        if str(payload.emoji) not in emojis:
+            return False
+        # Was the message sent in a channel (not a DM)?
+        if not payload.channel_id:
+            return False
+        if not self.reactor_is_human(payload):
+            return False
+        return True
+
+    async def get_reaction_message(
+        self,
+        payload: discord.RawReactionActionEvent,
+    ) -> Optional[discord.Message]:
+        with suppress(discord.NotFound):
+            channel = self.bot.get_channel(payload.channel_id)
+            if not channel:
+                return None
+            message: discord.Message = await channel.fetch_message(payload.message_id)
+        return message
+
+    def reactor_is_human(self, payload: discord.RawReactionActionEvent) -> bool:
+        with suppress(discord.NotFound):
+            member = self.bot.get_user(payload.user_id)
+        return not bool(getattr(member, "bot", None))
 
 
 def setup(bot: Bot) -> None:

--- a/bot/exts/meta.py
+++ b/bot/exts/meta.py
@@ -80,7 +80,9 @@ class Meta(Cog):
             sum(guild.member_count for guild in self.bot.guilds) / n_guilds
         )
         max_to_display = 50
-        servers_display = "\n".join(guild.name for guild in self.bot.guilds)
+        servers_display = "\n".join(
+            f"{guild.name} `{guild.member_count}`" for guild in self.bot.guilds
+        )
         remaining = max(n_guilds - max_to_display, 0)
         if remaining:
             servers_display += f"\n+{remaining} more"


### PR DESCRIPTION
Need to use `on_raw_reaction_remove` due to https://github.com/Rapptz/discord.py/issues/6099.

This is a more robust implementation anyway since it means that the team maker will still work after the bot restarts.