### PR TITLE
fix(practice): handle DST transition

### DIFF
--- a/bot/exts/practices/daily_message.py
+++ b/bot/exts/practices/daily_message.py
@@ -111,7 +111,15 @@ class DailyMessage(Cog, name="Daily Message"):  # type: ignore
         logger.info(f'sending daily message for guild: "{guild.name}" in #{channel.name}')
         guild_id = guild.id
         dtime = dtime or utcnow()
-        sessions = await get_practice_sessions(guild_id, dtime=dtime)
+        prefer_dates_from = (
+            "current_period" if dtime.date() <= dt.date.today() else "future"
+        )
+        parse_settings = {"PREFER_DATES_FROM": prefer_dates_from}
+        sessions = await get_practice_sessions(
+            guild_id,
+            dtime=dtime,
+            parse_settings=parse_settings,
+        )
         embed = await make_practice_session_embed(guild_id, sessions, dtime=dtime)
         file_ = None
 

--- a/bot/utils/datetimes.py
+++ b/bot/utils/datetimes.py
@@ -4,6 +4,7 @@ from typing import Tuple
 
 import dateparser
 import pytz
+from pytz.tzinfo import StaticTzInfo
 
 import pytz_informal
 
@@ -66,8 +67,10 @@ def parse_human_readable_datetime(
     return parsed.astimezone(dt.timezone.utc), used_timezone
 
 
-def display_timezone(tzinfo: dt.tzinfo, dtime: dt.datetime) -> str:
-    ret = tzinfo.tzname(dtime.replace(tzinfo=None))
+def display_timezone(tzinfo: StaticTzInfo, dtime: dt.datetime) -> str:
+    # Pass is_dst False to handle ambiguous datetimes
+    # NOTE: America/Los_Angeles will still display correctly as PDT after DST ends
+    ret = tzinfo.tzname(dtime.replace(tzinfo=None), is_dst=False)
     assert ret is not None
     return ret
 


### PR DESCRIPTION
Fixes this issue parsing the timezone name for an entry in the schedule at "Saturday 6pm PST"
```
Traceback (most recent call last):
  File "/Users/sloria/.pyenv/versions/HowSignBot/lib/python3.9/site-packages/discord/ext/commands/core.py", line 85, in wrapped
    ret = await coro(*args, **kwargs)
  File "/Users/sloria/projects/OpenASL/HowSignBot/bot/exts/practices/daily_message.py", line 99, in send_daily_message_command
    await self.send_daily_message(channel_id, send_dtime)
  File "/Users/sloria/projects/OpenASL/HowSignBot/bot/exts/practices/daily_message.py", line 123, in send_daily_message
    embed = await make_practice_session_embed(guild_id, sessions, dtime=dtime)
  File "/Users/sloria/projects/OpenASL/HowSignBot/bot/exts/practices/_practice_sessions.py", line 112, in make_practice_session_embed
    title = format_multi_time(session.dtime)
  File "/Users/sloria/projects/OpenASL/HowSignBot/bot/utils/datetimes.py", line 86, in format_multi_time
    pacific_dstr = display_time(dtime, time_format, tzinfo=PACIFIC)
  File "/Users/sloria/projects/OpenASL/HowSignBot/bot/utils/datetimes.py", line 76, in display_time
    return dtime.astimezone(tzinfo).strftime(time_format) + display_timezone(
  File "/Users/sloria/projects/OpenASL/HowSignBot/bot/utils/datetimes.py", line 70, in display_timezone
    ret = tzinfo.tzname(dtime.replace(tzinfo=None))
  File "/Users/sloria/.pyenv/versions/HowSignBot/lib/python3.9/site-packages/pytz/tzinfo.py", line 499, in tzname
    dt = self.localize(dt, is_dst)
  File "/Users/sloria/.pyenv/versions/HowSignBot/lib/python3.9/site-packages/pytz/tzinfo.py", line 341, in localize
    raise NonExistentTimeError(dt)
pytz.exceptions.NonExistentTimeError: 2021-03-14 02:00:00

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/sloria/.pyenv/versions/HowSignBot/lib/python3.9/site-packages/discord/ext/commands/bot.py", line 902, in invoke
    await ctx.command.invoke(ctx)
  File "/Users/sloria/.pyenv/versions/HowSignBot/lib/python3.9/site-packages/discord/ext/commands/core.py", line 864, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/Users/sloria/.pyenv/versions/HowSignBot/lib/python3.9/site-packages/discord/ext/commands/core.py", line 94, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: NonExistentTimeError: 2021-03-14 02:00:00
```